### PR TITLE
Fixed 'Contribute on Github' button on homepage

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -248,8 +248,8 @@ const Home = () => {
             </Button>
             <Button 
               size="lg"
-              variant="outline"
-              className="border-2 border-primary-foreground text-primary-foreground hover:bg-primary-foreground hover:text-primary font-semibold"
+              variant="secondary"
+              className="bg-background hover:bg-background/90 text-foreground font-semibold"
               asChild
             >
               <a href="https://github.com/avinash201199/Free-programming-books" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Fixes #44 

Fixed the code to ensure that the 'Contribute on Github' button on the homepage has visible text. It should look the same as the button on its left, the 'Explore Books' button.