### PR TITLE
feat(search): add relevance-scored search, filters, sorting, navbar search, and /search route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import About from "./pages/About";
 import Contributors from "./pages/Contributors";
 import Contact from "./pages/Contact";
 import NotFound from "./pages/NotFound";
+import Search from "./pages/Search";
 
 const queryClient = new QueryClient();
 
@@ -26,6 +27,7 @@ const App = () => (
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/books" element={<Books />} />
+              <Route path="/search" element={<Search />} />
               <Route path="/about" element={<About />} />
               <Route path="/contributors" element={<Contributors />} />
               <Route path="/contact" element={<Contact />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { Menu, X, BookOpen } from "lucide-react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Menu, X, BookOpen, Search as SearchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const location = useLocation();
+  const navigate = useNavigate();
 
   const navLinks = [
     { path: "/", label: "Home" },
@@ -33,7 +36,22 @@ const Navbar = () => {
           </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center gap-1">
+          <div className="hidden md:flex items-center gap-3">
+            {/* Search */}
+            <div className="relative">
+              <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    navigate(`/search${query ? `?q=${encodeURIComponent(query)}` : ""}`);
+                  }
+                }}
+                placeholder="Search books..."
+                className="pl-8 h-9 w-64"
+              />
+            </div>
             {navLinks.map((link) => (
               <Link key={link.path} to={link.path}>
                 <Button
@@ -78,6 +96,22 @@ const Navbar = () => {
         {/* Mobile Navigation */}
         {isOpen && (
           <div className="md:hidden py-4 space-y-2 animate-fade-in">
+            {/* Mobile Search */}
+            <div className="relative">
+              <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    setIsOpen(false);
+                    navigate(`/search${query ? `?q=${encodeURIComponent(query)}` : ""}`);
+                  }
+                }}
+                placeholder="Search books..."
+                className="pl-8 h-10"
+              />
+            </div>
             {navLinks.map((link) => (
               <Link
                 key={link.path}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,89 @@
+import { books as allBooks, type Book } from "@/data/books";
+
+export type SortOption = "relevance" | "title" | "category" | "year";
+
+export interface SearchFilters {
+  category?: string;
+  language?: string;
+  level?: string;
+}
+
+export interface SearchResult {
+  book: Book;
+  score: number;
+}
+
+function normalize(text: string): string {
+  return text.toLowerCase();
+}
+
+function fieldMatchScore(queryTokens: string[], fieldValue: string, weight: number): number {
+  if (!fieldValue) return 0;
+  const value = normalize(fieldValue);
+  let score = 0;
+  for (const token of queryTokens) {
+    if (!token) continue;
+    if (value === token) score += weight * 4; // exact
+    else if (value.startsWith(token)) score += weight * 3; // prefix
+    else if (value.includes(token)) score += weight; // substring
+  }
+  return score;
+}
+
+export function searchBooks(
+  query: string,
+  sourceBooks: Book[] = allBooks,
+  filters: SearchFilters = {},
+  sortBy: SortOption = "relevance",
+): SearchResult[] {
+  const q = normalize(query.trim());
+  const tokens = q.split(/\s+/).filter(Boolean);
+
+  const matchesFilters = (book: Book) => {
+    if (filters.category && filters.category !== "all" && book.category !== filters.category) return false;
+    if (filters.language && filters.language !== "all" && book.language !== filters.language) return false;
+    if (filters.level && filters.level !== "all" && book.level !== filters.level) return false;
+    return true;
+  };
+
+  const results: SearchResult[] = sourceBooks
+    .filter(matchesFilters)
+    .map((book) => {
+      if (tokens.length === 0) {
+        return { book, score: 0 };
+      }
+
+      let score = 0;
+      score += fieldMatchScore(tokens, book.title, 5);
+      score += fieldMatchScore(tokens, book.author, 3);
+      score += fieldMatchScore(tokens, book.description, 2);
+      score += fieldMatchScore(tokens, book.category, 1.5);
+      score += fieldMatchScore(tokens, book.language, 1);
+      score += book.tags?.reduce((acc, tag) => acc + fieldMatchScore(tokens, tag, 3), 0) ?? 0;
+
+      // small bonus for featured books
+      if (book.featured) score += 1;
+
+      return { book, score };
+    })
+    .filter((r) => tokens.length === 0 ? true : r.score > 0);
+
+  switch (sortBy) {
+    case "title":
+      results.sort((a, b) => a.book.title.localeCompare(b.book.title));
+      break;
+    case "category":
+      results.sort((a, b) => a.book.category.localeCompare(b.book.category) || a.book.title.localeCompare(b.book.title));
+      break;
+    case "year":
+      results.sort((a, b) => (b.book.year ?? 0) - (a.book.year ?? 0));
+      break;
+    case "relevance":
+    default:
+      results.sort((a, b) => b.score - a.score || a.book.title.localeCompare(b.book.title));
+  }
+
+  return results;
+}
+
+

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Search as SearchIcon, SlidersHorizontal, X } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import BookCard from "@/components/BookCard";
+import { books, categories, languages, levels } from "@/data/books";
+import { searchBooks, type SortOption } from "@/lib/search";
+
+function useQueryParam(name: string): string {
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search).get(name) ?? "", [search, name]);
+}
+
+const Search = () => {
+  const navigate = useNavigate();
+  const initialQ = useQueryParam("q");
+  const initialCategory = useQueryParam("category") || "all";
+  const initialLanguage = useQueryParam("language") || "all";
+  const initialLevel = useQueryParam("level") || "all";
+  const initialSort = (useQueryParam("sort") || "relevance") as SortOption;
+
+  const [q, setQ] = useState(initialQ);
+  const [category, setCategory] = useState(initialCategory);
+  const [language, setLanguage] = useState(initialLanguage);
+  const [level, setLevel] = useState(initialLevel);
+  const [sort, setSort] = useState<SortOption>(initialSort);
+  const [showFilters, setShowFilters] = useState(false);
+
+  // Keep URL in sync
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (category && category !== "all") params.set("category", category);
+    if (language && language !== "all") params.set("language", language);
+    if (level && level !== "all") params.set("level", level);
+    if (sort && sort !== "relevance") params.set("sort", sort);
+    navigate({ pathname: "/search", search: params.toString() }, { replace: true });
+  }, [q, category, language, level, sort, navigate]);
+
+  const results = useMemo(() => {
+    return searchBooks(q, books, { category, language, level }, sort);
+  }, [q, category, language, level, sort]);
+
+  const clearAll = () => {
+    setQ("");
+    setCategory("all");
+    setLanguage("all");
+    setLevel("all");
+    setSort("relevance");
+  };
+
+  const hasActiveFilters = category !== "all" || language !== "all" || level !== "all" || q !== "" || sort !== "relevance";
+
+  return (
+    <div className="min-h-screen py-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <h1 className="text-3xl sm:text-4xl font-bold">Search</h1>
+          <p className="text-muted-foreground">Find books by title, author, tags, description, category, or language.</p>
+        </div>
+
+        <Card className="p-6 mb-8 border-2">
+          <div className="space-y-4">
+            <div className="relative">
+              <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground" />
+              <Input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Search books..."
+                className="pl-10 h-12 text-base"
+              />
+            </div>
+
+            <div className="flex items-center justify-between md:hidden">
+              <Button variant="outline" className="w-full" onClick={() => setShowFilters(!showFilters)}>
+                <SlidersHorizontal className="h-4 w-4 mr-2" />
+                {showFilters ? "Hide Filters" : "Show Filters"}
+              </Button>
+            </div>
+
+            <div className={`grid grid-cols-1 md:grid-cols-5 gap-4 ${showFilters ? 'block' : 'hidden md:grid'}`}>
+              <Select value={category} onValueChange={setCategory}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Category" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Categories</SelectItem>
+                  {categories.map((c) => (
+                    <SelectItem key={c} value={c}>{c}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select value={language} onValueChange={setLanguage}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Language" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Languages</SelectItem>
+                  {languages.map((l) => (
+                    <SelectItem key={l} value={l}>{l}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select value={level} onValueChange={setLevel}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Level" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Levels</SelectItem>
+                  {levels.map((lvl) => (
+                    <SelectItem key={lvl} value={lvl}>{lvl}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select value={sort} onValueChange={(v) => setSort(v as SortOption)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Sort" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="relevance">Relevance</SelectItem>
+                  <SelectItem value="title">Title</SelectItem>
+                  <SelectItem value="category">Category</SelectItem>
+                  <SelectItem value="year">Year</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {hasActiveFilters && (
+                <Button variant="outline" className="w-full" onClick={clearAll}>
+                  <X className="h-4 w-4 mr-2" />
+                  Clear
+                </Button>
+              )}
+            </div>
+
+            {hasActiveFilters && (
+              <div className="flex flex-wrap gap-2 pt-2">
+                {q && <Badge variant="secondary" className="px-3 py-1">Search: "{q}"</Badge>}
+                {category !== "all" && <Badge variant="secondary" className="px-3 py-1">Category: {category}</Badge>}
+                {language !== "all" && <Badge variant="secondary" className="px-3 py-1">Language: {language}</Badge>}
+                {level !== "all" && <Badge variant="secondary" className="px-3 py-1">Level: {level}</Badge>}
+                {sort !== "relevance" && <Badge variant="secondary" className="px-3 py-1">Sort: {sort}</Badge>}
+              </div>
+            )}
+          </div>
+        </Card>
+
+        <div className="flex items-center justify-between mb-6">
+          <p className="text-muted-foreground">
+            Showing <span className="font-semibold text-foreground">{results.length}</span> results
+          </p>
+        </div>
+
+        {results.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 animate-fade-in">
+            {results.map((r) => (
+              <BookCard key={r.book.id} book={r.book} />
+            ))}
+          </div>
+        ) : (
+          <Card className="p-12 text-center">
+            <SearchIcon className="h-16 w-16 mx-auto text-muted-foreground/50 mb-4" />
+            <h3 className="text-xl font-semibold mb-2">No results</h3>
+            <p className="text-muted-foreground mb-4">Try different keywords or clear filters</p>
+            <Button onClick={clearAll} variant="outline">Clear All</Button>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Search;
+
+


### PR DESCRIPTION
Implemented a fully functional search interface with client-side relevance scoring.
Added filters (Category, Language, Level) and sorting (Relevance, Title, Category, Year).
Synced query params to URL for shareable deep links.

![Screenshot 2025-10-09 at 3 49 21 PM](https://github.com/user-attachments/assets/2d732add-bc66-4c07-9a32-7b577e2b3473)

![Screenshot 2025-10-09 at 3 52 04 PM](https://github.com/user-attachments/assets/9a929e6b-b066-4347-a88a-1f0ce9f5aa28)
